### PR TITLE
Add (optional) Lambda subnets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,14 +1,22 @@
 locals {
   az_ids          = [for zone in var.availability_zones : substr(zone, length(zone) - 1, 1)]
   lambda_subnets  = var.lambda_subnet ? local.zones : 0
-  vpc_subnet_bits = regex("\\/(\\d{1,2})$", var.cidr_block)[0]
+  vpc_subnet_bits = tonumber(regex("\\/(\\d{1,2})$", var.cidr_block)[0])
   zones           = length(var.availability_zones)
 
-  # Calculate the newbits as used by the cidrsubnet function.
-  # https://www.terraform.io/docs/configuration/functions/cidrsubnet.html
+  # Calculate the newbits as used by the cidrsubnets function.
+  # https://www.terraform.io/docs/configuration/functions/cidrsubnets.html
   private_newbits = var.private_subnet_bits - local.vpc_subnet_bits
   public_newbits  = var.public_subnet_bits - local.vpc_subnet_bits
   lambda_newbits  = var.lambda_subnet_bits - local.vpc_subnet_bits
+
+  # Build the new-bits list of all the subnets used. The "formatlist" is needed to work around a Terraform bug:
+  # https://github.com/hashicorp/terraform/issues/22576 / https://github.com/hashicorp/terraform/issues/22404
+  mandatory_subnets = concat(formatlist("%d", [for az in var.availability_zones: local.public_newbits]), formatlist("%d", [for az in var.availability_zones: local.private_newbits]))
+  # Add Lambda's if specified
+  all_subnets = var.lambda_subnet ? concat(local.mandatory_subnets, formatlist("%d", [for az in var.availability_zones: local.lambda_newbits])) : local.mandatory_subnets
+
+  cidr_subnets = cidrsubnets(var.cidr_block, local.all_subnets...)  
 }
 
 resource "aws_vpc" "default" {
@@ -47,7 +55,7 @@ resource "aws_nat_gateway" "default" {
 
 resource "aws_subnet" "public" {
   count                   = local.zones
-  cidr_block              = cidrsubnet(var.cidr_block, local.public_newbits, count.index)
+  cidr_block              = local.cidr_subnets[count.index]
   availability_zone       = var.availability_zones[count.index]
   map_public_ip_on_launch = true
   vpc_id                  = aws_vpc.default.id
@@ -59,7 +67,7 @@ resource "aws_subnet" "public" {
 
 resource "aws_subnet" "private" {
   count                   = local.zones
-  cidr_block              = cidrsubnet(var.cidr_block, local.private_newbits, count.index + local.zones)
+  cidr_block              = local.cidr_subnets[local.zones + count.index]
   availability_zone       = var.availability_zones[count.index]
   map_public_ip_on_launch = false
   vpc_id                  = aws_vpc.default.id
@@ -71,7 +79,7 @@ resource "aws_subnet" "private" {
 
 resource "aws_subnet" "lambda" {
   count                   = local.lambda_subnets
-  cidr_block              = cidrsubnet(var.cidr_block, local.lambda_newbits, 1 + count.index)
+  cidr_block              = local.cidr_subnets[local.zones + local.zones + count.index]
   availability_zone       = var.availability_zones[count.index]
   map_public_ip_on_launch = false
   vpc_id                  = aws_vpc.default.id

--- a/main.tf
+++ b/main.tf
@@ -71,7 +71,7 @@ resource "aws_subnet" "private" {
 
 resource "aws_subnet" "lambda" {
   count                   = local.lambda_subnets
-  cidr_block              = cidrsubnet(var.cidr_block, local.lambda_newbits, count.index + (local.zones * 2))
+  cidr_block              = cidrsubnet(var.cidr_block, local.lambda_newbits, 1 + count.index)
   availability_zone       = var.availability_zones[count.index]
   map_public_ip_on_launch = false
   vpc_id                  = aws_vpc.default.id

--- a/main.tf
+++ b/main.tf
@@ -70,8 +70,8 @@ resource "aws_subnet" "private" {
 }
 
 resource "aws_subnet" "lambda" {
-  count                   = local.lambda_subnet_count
-  cidr_block              = cidrsubnet(var.cidr_block, local.lambda_subnet_newbits, count.index + local.zones)
+  count                   = local.lambda_subnets
+  cidr_block              = cidrsubnet(var.cidr_block, local.lambda_subnet_newbits, count.index + (local.zones * 2))
   availability_zone       = var.availability_zones[count.index]
   map_public_ip_on_launch = false
   vpc_id                  = aws_vpc.default.id

--- a/outputs.tf
+++ b/outputs.tf
@@ -18,6 +18,26 @@ output "nat_gateway_ids" {
   description = "IDs of the NAT gateways"
 }
 
+output "lambda_subnet_ids" {
+  value       = aws_subnet.lambda[*].id
+  description = "IDs of the Lambda subnets"
+}
+
+output "lambda_subnet_arns" {
+  value       = aws_subnet.lambda[*].arn
+  description = "ARNs of the Lambda subnets"
+}
+
+output "lambda_subnet_cidr_blocks" {
+  value       = aws_subnet.lambda[*].cidr_block
+  description = "CIDR blocks of the Lambda subnets"
+}
+
+output "lambda_route_table_ids" {
+  value       = aws_route_table.lambda[*].id
+  description = "IDs of the Lambda route tables"
+}
+
 output "public_subnet_ids" {
   value       = aws_subnet.public[*].id
   description = "IDs of the public subnets"
@@ -56,24 +76,4 @@ output "private_subnet_cidr_blocks" {
 output "private_route_table_ids" {
   value       = aws_route_table.private[*].id
   description = "IDs of the private route tables"
-}
-
-output "lambda_subnet_ids" {
-  value       = aws_subnet.lambda[*].id
-  description = "IDs of the Lambda subnets"
-}
-
-output "lambda_subnet_arns" {
-  value       = aws_subnet.lambda[*].arn
-  description = "ARNs of the Lambda subnets"
-}
-
-output "lambda_subnet_cidr_blocks" {
-  value       = aws_subnet.lambda[*].cidr_block
-  description = "CIDR blocks of the Lambda subnets"
-}
-
-output "lambda_route_table_ids" {
-  value       = aws_route_table.lambda[*].id
-  description = "IDs of the Lambda route tables"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -57,3 +57,23 @@ output "private_route_table_ids" {
   value       = aws_route_table.private[*].id
   description = "IDs of the private route tables"
 }
+
+output "lambda_subnet_ids" {
+  value       = aws_subnet.lambda[*].id
+  description = "IDs of the Lambda subnets"
+}
+
+output "lambda_subnet_arns" {
+  value       = aws_subnet.lambda[*].arn
+  description = "ARNs of the Lambda subnets"
+}
+
+output "lambda_subnet_cidr_blocks" {
+  value       = aws_subnet.lambda[*].cidr_block
+  description = "CIDR blocks of the Lambda subnets"
+}
+
+output "lambda_route_table_ids" {
+  value       = aws_route_table.lambda[*].id
+  description = "IDs of the Lambda route tables"
+}

--- a/variables.tf
+++ b/variables.tf
@@ -17,3 +17,28 @@ variable "tags" {
   type        = map(string)
   description = "A mapping of tags to assign to the resources"
 }
+
+variable "lambda_subnet" {
+  type        = bool
+  default     = false
+  description = "Whether to create a subnet for Lambda functions running in the VPC"
+}
+
+variable "public_subnet_suffix" {
+  type        = number
+  default     = 24
+  description = "The suffix specifying the size of the Public subnets, e.g. (default) value 24 results in /24 subnets"
+}
+
+variable "private_subnet_suffix" {
+  type        = number
+  default     = 24
+  description = "The suffix specifying the size of the Private subnets, e.g. (default) value 24 results in /24 subnets"
+}
+
+variable "lambda_subnet_suffix" {
+  type        = number
+  default     = 19
+  description = "The suffix specifying the size of the Lambda subnets, e.g. (default) value 19 results in /19 subnets"
+}
+

--- a/variables.tf
+++ b/variables.tf
@@ -13,32 +13,31 @@ variable "availability_zones" {
   description = "A list of availability zones for the subnets"
 }
 
-variable "tags" {
-  type        = map(string)
-  description = "A mapping of tags to assign to the resources"
-}
-
 variable "lambda_subnet" {
   type        = bool
   default     = false
   description = "Whether to create a subnet for Lambda functions running in the VPC"
 }
 
-variable "public_subnet_suffix" {
-  type        = number
-  default     = 24
-  description = "The suffix specifying the size of the Public subnets, e.g. (default) value 24 results in /24 subnets"
-}
-
-variable "private_subnet_suffix" {
-  type        = number
-  default     = 24
-  description = "The suffix specifying the size of the Private subnets, e.g. (default) value 24 results in /24 subnets"
-}
-
-variable "lambda_subnet_suffix" {
+variable "lambda_subnet_bits" {
   type        = number
   default     = 19
-  description = "The suffix specifying the size of the Lambda subnets, e.g. (default) value 19 results in /19 subnets"
+  description = "The number of bits used for the subnet mask"
 }
 
+variable "public_subnet_bits" {
+  type        = number
+  default     = 24
+  description = "The number of bits used for the subnet mask"
+}
+
+variable "private_subnet_bits" {
+  type        = number
+  default     = 24
+  description = "The number of bits used for the subnet mask"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "A mapping of tags to assign to the resources"
+}

--- a/version.tf
+++ b/version.tf
@@ -1,3 +1,3 @@
 terraform {
-  required_version = "~> 0.12.0"
+  required_version = "~> 0.12.10"
 }


### PR DESCRIPTION
This PR adds support for a (dedicated) Lambda subnet for running Lambda's from within the VPC.

Also made the subnet sizes configurable for all 3 subnets (Public, Private and Lambda), variable is configured using the Cidr Suffix: `24` results in `/24` subnets being created. This is done to make it more clear than using the [cidrsubnets](https://www.terraform.io/docs/configuration/functions/cidrsubnet.html) `newbits` value

Default values keeps everything  backwards compatible

_The `cidrsubnets` function in introduced in 0.12.10_