### PR TITLE
Resource naming consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ environment. See the examples directory for reference material.
 ```terraform
 module "full_vpc" {
   source              = "git::git@github.com:schubergphilis/terraform-aws-mcaf-vpc.git"
-  stack               = "test"
+  context             = "test"
   cidr_block          = "192.168.0.0/24"
   availability_zones  = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
   public_subnet_bits  = 28

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ environment. See the examples directory for reference material.
 ```terraform
 module "full_vpc" {
   source              = "git::git@github.com:schubergphilis/terraform-aws-mcaf-vpc.git"
-  context             = "test"
+  name                = "test"
   cidr_block          = "192.168.0.0/24"
   availability_zones  = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
   public_subnet_bits  = 28

--- a/endpoints.tf
+++ b/endpoints.tf
@@ -9,7 +9,7 @@ resource "aws_vpc_endpoint" "transfer_server" {
   security_group_ids  = var.transfer_server.security_group_ids
   service_name        = data.aws_vpc_endpoint_service.transfer_server[0].service_name
   subnet_ids          = var.transfer_server.subnet_ids
-  tags                = merge(var.tags, { "Name" = "transfer-server-${var.context}" })
+  tags                = merge(var.tags, { "Name" = "transfer-server-${var.name}" })
   vpc_endpoint_type   = "Interface"
   vpc_id              = aws_vpc.default.id
 }

--- a/endpoints.tf
+++ b/endpoints.tf
@@ -9,7 +9,7 @@ resource "aws_vpc_endpoint" "transfer_server" {
   security_group_ids  = var.transfer_server.security_group_ids
   service_name        = data.aws_vpc_endpoint_service.transfer_server[0].service_name
   subnet_ids          = var.transfer_server.subnet_ids
-  tags                = merge(var.tags, { "Name" = "${var.stack}-transfer-server" })
+  tags                = merge(var.tags, { "Name" = "transfer-server-${var.context}" })
   vpc_endpoint_type   = "Interface"
   vpc_id              = aws_vpc.default.id
 }

--- a/examples/all/main.tf
+++ b/examples/all/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 
 module "full_vpc" {
   source              = "../../"
-  stack               = "test"
+  context             = "test"
   cidr_block          = "192.168.0.0/24"
   availability_zones  = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
   public_subnet_bits  = 28
@@ -18,7 +18,7 @@ module "full_vpc" {
 
 module "full_vpc_with_lambda" {
   source              = "../../"
-  stack               = "test"
+  context             = "test"
   cidr_block          = "192.168.1.0/24"
   availability_zones  = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
   public_subnet_bits  = 28

--- a/examples/all/main.tf
+++ b/examples/all/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 
 module "full_vpc" {
   source              = "../../"
-  context             = "test"
+  name                = "test"
   cidr_block          = "192.168.0.0/24"
   availability_zones  = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
   public_subnet_bits  = 28
@@ -18,7 +18,7 @@ module "full_vpc" {
 
 module "full_vpc_with_lambda" {
   source              = "../../"
-  context             = "test"
+  name                = "test"
   cidr_block          = "192.168.1.0/24"
   availability_zones  = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
   public_subnet_bits  = 28

--- a/examples/lambda/main.tf
+++ b/examples/lambda/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 
 module "private_vpc" {
   source             = "../../"
-  stack              = "test"
+  context            = "test"
   cidr_block         = "192.168.0.0/24"
   availability_zones = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
   lambda_subnet_bits = 26

--- a/examples/lambda/main.tf
+++ b/examples/lambda/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 
 module "private_vpc" {
   source             = "../../"
-  context            = "test"
+  name               = "test"
   cidr_block         = "192.168.0.0/24"
   availability_zones = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
   lambda_subnet_bits = 26

--- a/examples/private/main.tf
+++ b/examples/private/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 
 module "private_vpc" {
   source              = "../../"
-  stack               = "test"
+  context         = "test"
   cidr_block          = "192.168.0.0/24"
   availability_zones  = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
   private_subnet_bits = 26
@@ -17,7 +17,7 @@ module "private_vpc" {
 
 module "private_vpc_with_lambda" {
   source              = "../../"
-  stack               = "test"
+  context             = "test"
   cidr_block          = "192.168.1.0/24"
   availability_zones  = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
   private_subnet_bits = 28

--- a/examples/private/main.tf
+++ b/examples/private/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 
 module "private_vpc" {
   source              = "../../"
-  context             = "test"
+  name                = "test"
   cidr_block          = "192.168.0.0/24"
   availability_zones  = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
   private_subnet_bits = 26
@@ -17,7 +17,7 @@ module "private_vpc" {
 
 module "private_vpc_with_lambda" {
   source              = "../../"
-  context             = "test"
+  name                = "test"
   cidr_block          = "192.168.1.0/24"
   availability_zones  = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
   private_subnet_bits = 28

--- a/examples/private/main.tf
+++ b/examples/private/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 
 module "private_vpc" {
   source              = "../../"
-  context         = "test"
+  context             = "test"
   cidr_block          = "192.168.0.0/24"
   availability_zones  = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
   private_subnet_bits = 26

--- a/examples/public/main.tf
+++ b/examples/public/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 
 module "public_only_vpc" {
   source             = "../../"
-  context        = "test"
+  context            = "test"
   cidr_block         = "192.168.0.0/24"
   availability_zones = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
   public_subnet_bits = 26

--- a/examples/public/main.tf
+++ b/examples/public/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 
 module "public_only_vpc" {
   source             = "../../"
-  context            = "test"
+  name               = "test"
   cidr_block         = "192.168.0.0/24"
   availability_zones = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
   public_subnet_bits = 26
@@ -17,7 +17,7 @@ module "public_only_vpc" {
 
 module "public_vpc_with_lambda" {
   source             = "../../"
-  context            = "test"
+  name               = "test"
   cidr_block         = "192.168.1.0/24"
   availability_zones = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
   public_subnet_bits = 28

--- a/examples/public/main.tf
+++ b/examples/public/main.tf
@@ -5,7 +5,7 @@ provider "aws" {
 
 module "public_only_vpc" {
   source             = "../../"
-  stack              = "test"
+  context        = "test"
   cidr_block         = "192.168.0.0/24"
   availability_zones = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
   public_subnet_bits = 26
@@ -17,7 +17,7 @@ module "public_only_vpc" {
 
 module "public_vpc_with_lambda" {
   source             = "../../"
-  stack              = "test"
+  context            = "test"
   cidr_block         = "192.168.1.0/24"
   availability_zones = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
   public_subnet_bits = 28

--- a/main.tf
+++ b/main.tf
@@ -32,13 +32,13 @@ resource "aws_vpc" "default" {
   enable_dns_support   = true
   enable_dns_hostnames = true
   instance_tenancy     = "default"
-  tags                 = merge(var.tags, { "Name" = "${var.stack}-vpc" })
+  tags                 = merge(var.tags, { "Name" = "vpc-${var.context}" })
 }
 
 resource "aws_internet_gateway" "default" {
   count  = min(local.public_subnets, 1)
   vpc_id = aws_vpc.default.id
-  tags   = merge(var.tags, { "Name" = "${var.stack}-igw" })
+  tags   = merge(var.tags, { "Name" = "igw-${var.context}" })
 }
 
 resource "aws_eip" "nat" {
@@ -46,7 +46,7 @@ resource "aws_eip" "nat" {
   vpc   = true
 
   tags = merge(
-    var.tags, { "Name" = "${var.stack}-nat-${local.az_ids[count.index]}" }
+    var.tags, { "Name" = "eip-nat-${var.context}-${local.az_ids[count.index]}" }
   )
 
   depends_on = [aws_internet_gateway.default]
@@ -58,7 +58,7 @@ resource "aws_nat_gateway" "default" {
   subnet_id     = aws_subnet.public[count.index].id
 
   tags = merge(
-    var.tags, { "Name" = "${var.stack}-nat-${local.az_ids[count.index]}" }
+    var.tags, { "Name" = "nat-${var.context}-${local.az_ids[count.index]}" }
   )
 }
 
@@ -70,7 +70,7 @@ resource "aws_subnet" "public" {
   vpc_id                  = aws_vpc.default.id
 
   tags = merge(
-    { "Name" = "${var.stack}-public-${local.az_ids[count.index]}" },
+    { "Name" = "subnet-${var.context}-public-${local.az_ids[count.index]}" },
     var.public_subnet_tags,
     var.tags
   )
@@ -84,7 +84,7 @@ resource "aws_subnet" "private" {
   vpc_id                  = aws_vpc.default.id
 
   tags = merge(
-    { "Name" = "${var.stack}-private-${local.az_ids[count.index]}" },
+    { "Name" = "subnet-${var.context}-private-${local.az_ids[count.index]}" },
     var.private_subnet_tags,
     var.tags
   )
@@ -98,14 +98,14 @@ resource "aws_subnet" "lambda" {
   vpc_id                  = aws_vpc.default.id
 
   tags = merge(
-    var.tags, { "Name" = "${var.stack}-lambda-${local.az_ids[count.index]}" }
+    var.tags, { "Name" = "lambda-${var.context}-${local.az_ids[count.index]}" }
   )
 }
 
 resource "aws_route_table" "public" {
   count  = min(local.public_subnets, 1)
   vpc_id = aws_vpc.default.id
-  tags   = merge(var.tags, { "Name" = "${var.stack}-public" })
+  tags   = merge(var.tags, { "Name" = "route-table-${var.context}-public" })
 }
 
 resource "aws_route" "public" {
@@ -126,7 +126,7 @@ resource "aws_route_table" "private" {
   vpc_id = aws_vpc.default.id
 
   tags = merge(
-    var.tags, { "Name" = "${var.stack}-private-${local.az_ids[count.index]}" }
+    var.tags, { "Name" = "route-table-${var.context}-private-${local.az_ids[count.index]}" }
   )
 }
 
@@ -148,7 +148,7 @@ resource "aws_route_table" "lambda" {
   vpc_id = aws_vpc.default.id
 
   tags = merge(
-    var.tags, { "Name" = "${var.stack}-lambda-${local.az_ids[count.index]}" }
+    var.tags, { "Name" = "route-table-${var.context}-lambda-${local.az_ids[count.index]}" }
   )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -32,13 +32,13 @@ resource "aws_vpc" "default" {
   enable_dns_support   = true
   enable_dns_hostnames = true
   instance_tenancy     = "default"
-  tags                 = merge(var.tags, { "Name" = "vpc-${var.context}" })
+  tags                 = merge(var.tags, { "Name" = "vpc-${var.name}" })
 }
 
 resource "aws_internet_gateway" "default" {
   count  = min(local.public_subnets, 1)
   vpc_id = aws_vpc.default.id
-  tags   = merge(var.tags, { "Name" = "igw-${var.context}" })
+  tags   = merge(var.tags, { "Name" = "igw-${var.name}" })
 }
 
 resource "aws_eip" "nat" {
@@ -46,7 +46,7 @@ resource "aws_eip" "nat" {
   vpc   = true
 
   tags = merge(
-    var.tags, { "Name" = "eip-nat-${var.context}-${local.az_ids[count.index]}" }
+    var.tags, { "Name" = "eip-nat-${var.name}-${local.az_ids[count.index]}" }
   )
 
   depends_on = [aws_internet_gateway.default]
@@ -58,7 +58,7 @@ resource "aws_nat_gateway" "default" {
   subnet_id     = aws_subnet.public[count.index].id
 
   tags = merge(
-    var.tags, { "Name" = "nat-${var.context}-${local.az_ids[count.index]}" }
+    var.tags, { "Name" = "nat-${var.name}-${local.az_ids[count.index]}" }
   )
 }
 
@@ -70,7 +70,7 @@ resource "aws_subnet" "public" {
   vpc_id                  = aws_vpc.default.id
 
   tags = merge(
-    { "Name" = "subnet-${var.context}-public-${local.az_ids[count.index]}" },
+    { "Name" = "subnet-${var.name}-public-${local.az_ids[count.index]}" },
     var.public_subnet_tags,
     var.tags
   )
@@ -84,7 +84,7 @@ resource "aws_subnet" "private" {
   vpc_id                  = aws_vpc.default.id
 
   tags = merge(
-    { "Name" = "subnet-${var.context}-private-${local.az_ids[count.index]}" },
+    { "Name" = "subnet-${var.name}-private-${local.az_ids[count.index]}" },
     var.private_subnet_tags,
     var.tags
   )
@@ -98,14 +98,14 @@ resource "aws_subnet" "lambda" {
   vpc_id                  = aws_vpc.default.id
 
   tags = merge(
-    var.tags, { "Name" = "lambda-${var.context}-${local.az_ids[count.index]}" }
+    var.tags, { "Name" = "lambda-${var.name}-${local.az_ids[count.index]}" }
   )
 }
 
 resource "aws_route_table" "public" {
   count  = min(local.public_subnets, 1)
   vpc_id = aws_vpc.default.id
-  tags   = merge(var.tags, { "Name" = "route-table-${var.context}-public" })
+  tags   = merge(var.tags, { "Name" = "route-table-${var.name}-public" })
 }
 
 resource "aws_route" "public" {
@@ -126,7 +126,7 @@ resource "aws_route_table" "private" {
   vpc_id = aws_vpc.default.id
 
   tags = merge(
-    var.tags, { "Name" = "route-table-${var.context}-private-${local.az_ids[count.index]}" }
+    var.tags, { "Name" = "route-table-${var.name}-private-${local.az_ids[count.index]}" }
   )
 }
 
@@ -148,7 +148,7 @@ resource "aws_route_table" "lambda" {
   vpc_id = aws_vpc.default.id
 
   tags = merge(
-    var.tags, { "Name" = "route-table-${var.context}-lambda-${local.az_ids[count.index]}" }
+    var.tags, { "Name" = "route-table-${var.name}-lambda-${local.az_ids[count.index]}" }
   )
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -8,15 +8,15 @@ variable "cidr_block" {
   description = "The CIDR block for the VPC"
 }
 
-variable "context" {
-  type        = string
-  description = "Used as part of the resource names to indicate they are created and used within a specific context"
-}
-
 variable "lambda_subnet_bits" {
   type        = number
   default     = null
   description = "The number of bits used for the subnet mask"
+}
+
+variable "name" {
+  type        = string
+  description = "Used as part of the resource names to indicate they are created and used within a specific name"
 }
 
 variable "private_subnet_bits" {

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,11 @@ variable "cidr_block" {
   description = "The CIDR block for the VPC"
 }
 
+variable "context" {
+  type        = string
+  description = "Used as part of the resource names to indicate they are created and used within a specific context"
+}
+
 variable "lambda_subnet_bits" {
   type        = number
   default     = null
@@ -36,11 +41,6 @@ variable "public_subnet_tags" {
   type        = map(string)
   default     = {}
   description = "Additional tags to set on the public subnets"
-}
-
-variable "context" {
-  type        = string
-  description = "The workload name for the VPC if used in a workload context, the environment if used in a shared network context."
 }
 
 variable "tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -38,9 +38,9 @@ variable "public_subnet_tags" {
   description = "Additional tags to set on the public subnets"
 }
 
-variable "stack" {
+variable "context" {
   type        = string
-  description = "The stack name for the VPC"
+  description = "The workload name for the VPC if used in a workload context, the environment if used in a shared network context."
 }
 
 variable "tags" {


### PR DESCRIPTION
The use of "stack" as a variable is confusing for the context of AWS where stack is something very specific. Also when this module is used in a context of a shared network account with environment VPCs then it refers to something completely different. With that in mind the use of "context" seems a bit more appropriate. 

The naming of resources is inconsistent, with the same name appointed to the eip and the nat resources with no mention of their resource type, where the VPCs and other resources do have mention of their resource types in the naming. The above changes standardize on the usage of the resource type in the naming of the resource, moving it to the front so it is consistent with AWS resource id convention.