### PR TITLE
Correct naming

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -53,9 +53,9 @@ output "public_subnet_cidr_blocks" {
   description = "CIDR blocks of the public subnets"
 }
 
-output "public_route_table_id" {
+output "public_route_table_ids" {
   value       = aws_route_table.public[*].id
-  description = "ID of the public route table"
+  description = "IDs of the public route tables"
 }
 
 output "private_subnet_ids" {


### PR DESCRIPTION
Correct the naming of the `public_route_table_id`. It returns a list instead of a single id.