### PR TITLE
By default do not create NAT Gateway for public subnets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,7 @@ resource "aws_internet_gateway" "default" {
 }
 
 resource "aws_eip" "nat" {
-  count = local.public_subnets
+  count = var.enable_nat_gateway ? local.public_subnets : 0
   vpc   = true
 
   tags = merge(
@@ -53,7 +53,7 @@ resource "aws_eip" "nat" {
 }
 
 resource "aws_nat_gateway" "default" {
-  count         = local.public_subnets
+  count         = var.enable_nat_gateway ? local.public_subnets : 0
   allocation_id = aws_eip.nat[count.index].id
   subnet_id     = aws_subnet.public[count.index].id
 
@@ -131,7 +131,7 @@ resource "aws_route_table" "private" {
 }
 
 resource "aws_route" "private" {
-  count                  = local.private_subnets > 0 && local.public_subnets > 0 ? local.private_subnets : 0
+  count                  = var.enable_nat_gateway && local.private_subnets > 0 && local.public_subnets > 0 ? local.private_subnets : 0
   route_table_id         = aws_route_table.private[count.index].id
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = aws_nat_gateway.default[count.index].id
@@ -153,7 +153,7 @@ resource "aws_route_table" "lambda" {
 }
 
 resource "aws_route" "lambda" {
-  count                  = local.lambda_subnets > 0 && local.public_subnets > 0 ? local.lambda_subnets : 0
+  count                  = var.enable_nat_gateway && local.lambda_subnets > 0 && local.public_subnets > 0 ? local.lambda_subnets : 0
   route_table_id         = aws_route_table.lambda[count.index].id
   destination_cidr_block = "0.0.0.0/0"
   nat_gateway_id         = aws_nat_gateway.default[count.index].id

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,12 @@ variable "cidr_block" {
   description = "The CIDR block for the VPC"
 }
 
+variable "enable_nat_gateway" {
+  type        = bool
+  default     = true
+  description = "Should be true to provision NAT Gateways for each private subnet"
+}
+
 variable "lambda_subnet_bits" {
   type        = number
   default     = null


### PR DESCRIPTION
Save costs by not auto-creating a NAT for all public subnets.