### PR TITLE
enabling flowlogs and subnet sharing for the vpc.

### DIFF
--- a/flowlogs.tf
+++ b/flowlogs.tf
@@ -1,0 +1,64 @@
+data "aws_iam_policy_document" "log_stream_trust" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "sts:AssumeRole",
+    ]
+
+    principals {
+      type = "Service"
+
+      identifiers = [
+        "vpc-flow-logs.amazonaws.com",
+      ]
+    }
+  }
+}
+
+data "aws_iam_policy_document" "log_stream_action" {
+  statement {
+    effect = "Allow"
+
+    actions = [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams",
+    ]
+
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_role" "flow_logs" {
+  count              = var.flow_logs != null ? 1 : 0
+  assume_role_policy = data.aws_iam_policy_document.log_stream_trust.json
+  name               = var.flow_logs.iam_role_name
+}
+
+
+resource "aws_iam_role_policy" "flow_logs" {
+  count  = var.flow_logs != null ? 1 : 0
+  policy = data.aws_iam_policy_document.log_stream_action.json
+  role   = aws_iam_role.flow_logs[count.index].id
+  name   = "${var.flow_logs.iam_role_name}-action-policy"
+}
+
+resource "aws_cloudwatch_log_group" "flow_logs" {
+  count             = var.flow_logs != null ? 1 : 0
+  retention_in_days = var.flow_logs.retention_in_days
+  name              = "vpc-flow-logs-${var.name}"
+  tags              = {}
+}
+
+resource "aws_flow_log" "flow_logs" {
+  count           = var.flow_logs != null ? 1 : 0
+  vpc_id          = aws_vpc.default.id
+  iam_role_arn    = aws_iam_role.flow_logs[count.index].arn
+  traffic_type    = var.flow_logs.traffic_type
+  log_destination = aws_cloudwatch_log_group.flow_logs[count.index].arn
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -84,11 +84,11 @@ output "private_route_table_ids" {
 }
 
 output "subnet_share_id" {
-  value       =  var.share_public_subnets || var.share_private_subnets  ? aws_ram_resource_share.subnet_sharing[0].id : ""
+  value       = var.share_public_subnets || var.share_private_subnets ? aws_ram_resource_share.subnet_sharing[0].id : ""
   description = "The ID of the subnet share in resource access manager if any"
 }
 
 output "subnet_share_arn" {
-  value       =  var.share_public_subnets || var.share_private_subnets  ? aws_ram_resource_share.subnet_sharing[0].arn : ""
+  value       = var.share_public_subnets || var.share_private_subnets ? aws_ram_resource_share.subnet_sharing[0].arn : ""
   description = "The ARN of the subnet share in resource access manager if any"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -82,3 +82,13 @@ output "private_route_table_ids" {
   value       = aws_route_table.private[*].id
   description = "IDs of the private route tables"
 }
+
+output "subnet_share_id" {
+  value       =  var.share_public_subnets || var.share_private_subnets  ? aws_ram_resource_share.subnet_sharing.id : ""
+  description = "The ID of the subnet share in resource access manager if any"
+}
+
+output "subnet_share_arn" {
+  value       =  var.share_public_subnets || var.share_private_subnets  ? aws_ram_resource_share.subnet_sharing.arn : ""
+  description = "The ARN of the subnet share in resource access manager if any"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -84,11 +84,11 @@ output "private_route_table_ids" {
 }
 
 output "subnet_share_id" {
-  value       =  var.share_public_subnets || var.share_private_subnets  ? aws_ram_resource_share.subnet_sharing.id : ""
+  value       =  var.share_public_subnets || var.share_private_subnets  ? aws_ram_resource_share.subnet_sharing[0].id : ""
   description = "The ID of the subnet share in resource access manager if any"
 }
 
 output "subnet_share_arn" {
-  value       =  var.share_public_subnets || var.share_private_subnets  ? aws_ram_resource_share.subnet_sharing.arn : ""
+  value       =  var.share_public_subnets || var.share_private_subnets  ? aws_ram_resource_share.subnet_sharing[0].arn : ""
   description = "The ARN of the subnet share in resource access manager if any"
 }

--- a/subnet_sharing.tf
+++ b/subnet_sharing.tf
@@ -2,7 +2,10 @@ resource "aws_ram_resource_share" "subnet_sharing" {
   count                     = var.share_public_subnets || var.share_private_subnets ? 1 : 0
   name                      = "${var.prepend_resource_type ? "resource-share-" : ""}subnets-${var.name}"
   allow_external_principals = true
-  tags                      = { "environment" = var.name, "resource-type" = "ec2:Subnet" }
+  tags = merge(
+    { "environment" = var.name, "resource-type" = "ec2:Subnet" },
+    var.subnet_sharing_custom_tags
+  )
 }
 
 resource "aws_ram_resource_association" "private_subnets" {

--- a/subnet_sharing.tf
+++ b/subnet_sharing.tf
@@ -1,0 +1,18 @@
+resource "aws_ram_resource_share" "subnet_sharing" {
+  count                     = var.share_public_subnets || var.share_private_subnets ? 1 : 0
+  name                      = "${var.prepend_resource_type ? "resource-share-" : ""}subnets-${var.name}"
+  allow_external_principals = true
+  tags                      = { "environment" = var.name, "resource-type" = "ec2:Subnet" }
+}
+
+resource "aws_ram_resource_association" "private_subnets" {
+  for_each           = var.share_private_subnets ? toset(aws_subnet.private[*].arn) : []
+  resource_arn       = each.value
+  resource_share_arn = aws_ram_resource_share.subnet_sharing[0].arn
+}
+
+resource "aws_ram_resource_association" "public_subnets" {
+  for_each           = var.share_public_subnets ? toset(aws_subnet.public[*].arn) : []
+  resource_arn       = each.value
+  resource_share_arn = aws_ram_resource_share.subnet_sharing[0].arn
+}

--- a/variables.tf
+++ b/variables.tf
@@ -102,6 +102,12 @@ variable "share_public_subnets" {
   description = "If set it will share the public subnets through resource access manager"
 }
 
+variable "subnet_sharing_custom_tags" {
+  type        = map
+  default     = {}
+  description = "Custom tags to be set to a resource share for subnets"
+}
+
 variable "ssm_endpoint" {
   type = object({
     private_dns_enabled = bool

--- a/variables.tf
+++ b/variables.tf
@@ -102,12 +102,6 @@ variable "share_public_subnets" {
   description = "If set it will share the public subnets through resource access manager"
 }
 
-variable "subnet_sharing_custom_tags" {
-  type        = map
-  default     = {}
-  description = "Custom tags to be set to a resource share for subnets"
-}
-
 variable "ssm_endpoint" {
   type = object({
     private_dns_enabled = bool
@@ -126,6 +120,12 @@ variable "ssmmessages_endpoint" {
   })
   default     = null
   description = "Variables to provision an SSM messages endpoint to the VPC"
+}
+
+variable "subnet_sharing_custom_tags" {
+  type        = map(string)
+  default     = {}
+  description = "Custom tags to be set to a resource share for subnets"
 }
 
 variable "tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -34,6 +34,16 @@ variable "enable_nat_gateway" {
   description = "Set to true to provision a NAT Gateway for each private subnet"
 }
 
+variable "flow_logs" {
+  type = object({
+    retention_in_days = number
+    traffic_type      = string
+    iam_role_name     = string
+  })
+  default     = null
+  description = "Variables to enable flow logs for the VPC"
+}
+
 variable "lambda_subnet_bits" {
   type        = number
   default     = null
@@ -78,6 +88,18 @@ variable "public_subnet_tags" {
 variable "private_s3_endpoint" {
   default     = false
   description = "Deploy an S3 endpoint for your private subnets"
+}
+
+variable "share_private_subnets" {
+  type        = bool
+  default     = false
+  description = "If set it will share the private subnets through resource access manager"
+}
+
+variable "share_public_subnets" {
+  type        = bool
+  default     = false
+  description = "If set it will share the public subnets through resource access manager"
 }
 
 variable "ssm_endpoint" {


### PR DESCRIPTION
Enabling the flow logs flag with enable the flow logging with all appropriate roles and policies and log groups created automatically. Subnets can be shared per group, private or public and if enabled the sharing resource id and arn is output.