### PR TITLE
restrict the default security group to no rules

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -37,6 +37,11 @@ resource "aws_vpc" "default" {
   tags                 = merge(var.tags, { "Name" = "${var.prepend_resource_type ? "vpc-" : ""}${var.name}" })
 }
 
+resource "aws_default_security_group" "default" {
+  count = var.restrict_default_security_group ? 1 : 0
+  vpc_id = aws_vpc.default.id
+}
+
 resource "aws_internet_gateway" "default" {
   count  = min(local.public_subnets, 1)
   vpc_id = aws_vpc.default.id

--- a/main.tf
+++ b/main.tf
@@ -38,7 +38,7 @@ resource "aws_vpc" "default" {
 }
 
 resource "aws_default_security_group" "default" {
-  count = var.restrict_default_security_group ? 1 : 0
+  count  = var.restrict_default_security_group ? 1 : 0
   vpc_id = aws_vpc.default.id
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -101,6 +101,12 @@ variable "private_s3_endpoint" {
   description = "Deploy an S3 endpoint for your private subnets"
 }
 
+variable "restrict_default_security_group" {
+  type        = bool
+  default     = true
+  description = "Remove all rules from the default security group"
+}
+
 variable "share_private_subnets" {
   type        = bool
   default     = false

--- a/variables.tf
+++ b/variables.tf
@@ -103,8 +103,8 @@ variable "private_s3_endpoint" {
 
 variable "restrict_default_security_group" {
   type        = bool
-  default     = false
-  description = "Remove all rules from the default security group"
+  default     = true
+  description = "Set to true to remove all rules from the default security group"
 }
 
 variable "share_private_subnets" {

--- a/variables.tf
+++ b/variables.tf
@@ -103,7 +103,7 @@ variable "private_s3_endpoint" {
 
 variable "restrict_default_security_group" {
   type        = bool
-  default     = true
+  default     = false
   description = "Remove all rules from the default security group"
 }
 


### PR DESCRIPTION
The default security group when created has all traffic open to it. 

This change would make the VPC module default compliant with CIS control 

4.3 – Ensure the default security group of every VPC restricts all traffic

https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-cis-controls.html

Note that it will per default drop all rules out of the security group rather than making it optional. to disable the behaviour 
restrict_default_security_group = false
needs to be set.