### PR TITLE
Add custom tags possibility for VPC and IGW

### DIFF
--- a/.github/workflows/terraform-docs.yml
+++ b/.github/workflows/terraform-docs.yml
@@ -1,0 +1,25 @@
+---
+name: Terraform
+on:
+  push:
+    branches:
+      - master
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+jobs:
+  terraform-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+      - name: Update module usage docs and push any changes back to PR branch
+        uses: Dirrk/terraform-docs@v1.0.8
+        with:
+          tf_docs_args: '--sort-inputs-by-required'
+          tf_docs_git_commit_message: 'terraform-docs: Update module usage [skip ci]'
+          tf_docs_git_push: 'true'
+          tf_docs_output_file: README.md
+          tf_docs_output_method: inject
+          tf_docs_find_dir: .

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -40,23 +40,6 @@ jobs:
           tf_actions_subcommand: validate
           tf_actions_comment: true
 
-  terraform-docs:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-      - name: Update module usage docs and push any changes back to PR branch
-        uses: Dirrk/terraform-docs@v1.0.8
-        with:
-          tf_docs_args: '--sort-inputs-by-required'
-          tf_docs_git_commit_message: 'terraform-docs: Update module usage'
-          tf_docs_git_push: 'true'
-          tf_docs_output_file: README.md
-          tf_docs_output_method: inject
-          tf_docs_find_dir: .
-
   tfsec:
     name: tfsec
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ module "full_vpc" {
 | ec2messages\_endpoint | Variables to provision an EC2 messages endpoint to the VPC | <pre>object({<br>    private_dns_enabled = bool<br>    security_group_ids  = list(string)<br>    subnet_ids          = list(string)<br>  })</pre> | `null` | no |
 | enable\_nat\_gateway | Set to true to provision a NAT Gateway for each private subnet | `bool` | `true` | no |
 | flow\_logs | Variables to enable flow logs for the VPC | <pre>object({<br>    iam_role_name     = string<br>    log_group_name    = string<br>    retention_in_days = number<br>    traffic_type      = string<br>  })</pre> | `null` | no |
-| internet\_gateway\_custom\_tags | Custom tags to be added to the internet_gateway resource, will overwrite generic tags | `map(string)` | `{}` | no |
+| internet\_gateway\_tags | Additional tags to set on the internet gateway| `map(string)` | `{}` | no |
 | lambda\_subnet\_bits | The number of bits used for the subnet mask | `number` | `null` | no |
 | postfix | Postfix the role and policy names with Role and Policy | `bool` | `false` | no |
 | prepend\_resource\_type | If set it will prepend the resource type on the name of the resource. | `bool` | `false` | no |
@@ -65,8 +65,8 @@ module "full_vpc" {
 | ssm\_endpoint | Variables to provision an SSM endpoint to the VPC | <pre>object({<br>    private_dns_enabled = bool<br>    security_group_ids  = list(string)<br>    subnet_ids          = list(string)<br>  })</pre> | `null` | no |
 | ssmmessages\_endpoint | Variables to provision an SSM messages endpoint to the VPC | <pre>object({<br>    private_dns_enabled = bool<br>    security_group_ids  = list(string)<br>    subnet_ids          = list(string)<br>  })</pre> | `null` | no |
 | subnet\_sharing\_custom\_tags | Custom tags to be added to a resource share for subnets | `map(string)` | `{}` | no |
-| vpc\_custom\_tags | Custom tags to be added to the VPC-resource, will overwrite generic tags | `map(string)` | `{}` | no |
 | transfer\_server | Variables to provision a Transfer Server endpoint to the VPC | <pre>object({<br>    security_group_ids  = list(string)<br>    subnet_ids          = list(string)<br>    private_dns_enabled = bool<br>  })</pre> | `null` | no |
+| vpc\_tags | Additional tags to set on the VPC | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -43,12 +43,14 @@ module "full_vpc" {
 | cidr\_block | The CIDR block for the VPC | `string` | n/a | yes |
 | name | Used as part of the resource names to indicate they are created and used within a specific name | `string` | n/a | yes |
 | tags | A mapping of tags to assign to the resources | `map(string)` | n/a | yes |
+| create\_default\_security\_group | Set to false to not a default security group | `bool` | `true` | no |
 | dhcp\_options | DHCP options to assign to the VPC | <pre>object({<br>    domain_name          = string<br>    domain_name_servers  = list(string)<br>    netbios_name_servers = list(string)<br>    netbios_node_type    = number<br>    ntp_servers          = list(string)<br>  })</pre> | `null` | no |
 | ebs\_endpoint | Variables to provision an EBS endpoint to the VPC | <pre>object({<br>    private_dns_enabled = bool<br>    security_group_ids  = list(string)<br>    subnet_ids          = list(string)<br>  })</pre> | `null` | no |
 | ec2\_endpoint | Variables to provision an EC2 endpoint to the VPC | <pre>object({<br>    private_dns_enabled = bool<br>    security_group_ids  = list(string)<br>    subnet_ids          = list(string)<br>  })</pre> | `null` | no |
 | ec2messages\_endpoint | Variables to provision an EC2 messages endpoint to the VPC | <pre>object({<br>    private_dns_enabled = bool<br>    security_group_ids  = list(string)<br>    subnet_ids          = list(string)<br>  })</pre> | `null` | no |
 | enable\_nat\_gateway | Set to true to provision a NAT Gateway for each private subnet | `bool` | `true` | no |
 | flow\_logs | Variables to enable flow logs for the VPC | <pre>object({<br>    iam_role_name     = string<br>    log_group_name    = string<br>    retention_in_days = number<br>    traffic_type      = string<br>  })</pre> | `null` | no |
+| internet\_gateway\_custom\_tags | Custom tags to be added to the internet_gateway resource, will overwrite generic tags | `map(string)` | `{}` | no |
 | lambda\_subnet\_bits | The number of bits used for the subnet mask | `number` | `null` | no |
 | postfix | Postfix the role and policy names with Role and Policy | `bool` | `false` | no |
 | prepend\_resource\_type | If set it will prepend the resource type on the name of the resource. | `bool` | `false` | no |
@@ -58,12 +60,12 @@ module "full_vpc" {
 | private\_subnet\_tags | Additional tags to set on the private subnets | `map(string)` | `{}` | no |
 | public\_subnet\_bits | The number of bits used for the subnet mask | `number` | `null` | no |
 | public\_subnet\_tags | Additional tags to set on the public subnets | `map(string)` | `{}` | no |
-| restrict\_default\_security\_group | Set to true to remove all rules from the default security group | `bool` | `true` | no |
 | share\_private\_subnets | If set it will share the private subnets through resource access manager | `bool` | `false` | no |
 | share\_public\_subnets | If set it will share the public subnets through resource access manager | `bool` | `false` | no |
 | ssm\_endpoint | Variables to provision an SSM endpoint to the VPC | <pre>object({<br>    private_dns_enabled = bool<br>    security_group_ids  = list(string)<br>    subnet_ids          = list(string)<br>  })</pre> | `null` | no |
 | ssmmessages\_endpoint | Variables to provision an SSM messages endpoint to the VPC | <pre>object({<br>    private_dns_enabled = bool<br>    security_group_ids  = list(string)<br>    subnet_ids          = list(string)<br>  })</pre> | `null` | no |
 | subnet\_sharing\_custom\_tags | Custom tags to be added to a resource share for subnets | `map(string)` | `{}` | no |
+| vpc\_custom\_tags | Custom tags to be added to the VPC-resource, will overwrite generic tags | `map(string)` | `{}` | no |
 | transfer\_server | Variables to provision a Transfer Server endpoint to the VPC | <pre>object({<br>    security_group_ids  = list(string)<br>    subnet_ids          = list(string)<br>    private_dns_enabled = bool<br>  })</pre> | `null` | no |
 
 ## Outputs

--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ module "full_vpc" {
 | availability\_zones | A list of availability zones for the subnets | `list(string)` | n/a | yes |
 | cidr\_block | The CIDR block for the VPC | `string` | n/a | yes |
 | name | Used as part of the resource names to indicate they are created and used within a specific name | `string` | n/a | yes |
-| tags | A mapping of tags to assign to the resources | `map(string)` | n/a | yes |
+| tags | A mapping of tags to assign to all resources | `map(string)` | n/a | yes |
 | dhcp\_options | DHCP options to assign to the VPC | <pre>object({<br>    domain_name          = string<br>    domain_name_servers  = list(string)<br>    netbios_name_servers = list(string)<br>    netbios_node_type    = number<br>    ntp_servers          = list(string)<br>  })</pre> | `null` | no |
 | ebs\_endpoint | Variables to provision an EBS endpoint to the VPC | <pre>object({<br>    private_dns_enabled = bool<br>    security_group_ids  = list(string)<br>    subnet_ids          = list(string)<br>  })</pre> | `null` | no |
 | ec2\_endpoint | Variables to provision an EC2 endpoint to the VPC | <pre>object({<br>    private_dns_enabled = bool<br>    security_group_ids  = list(string)<br>    subnet_ids          = list(string)<br>  })</pre> | `null` | no |
 | ec2messages\_endpoint | Variables to provision an EC2 messages endpoint to the VPC | <pre>object({<br>    private_dns_enabled = bool<br>    security_group_ids  = list(string)<br>    subnet_ids          = list(string)<br>  })</pre> | `null` | no |
 | enable\_nat\_gateway | Set to true to provision a NAT Gateway for each private subnet | `bool` | `true` | no |
 | flow\_logs | Variables to enable flow logs for the VPC | <pre>object({<br>    iam_role_name     = string<br>    log_group_name    = string<br>    retention_in_days = number<br>    traffic_type      = string<br>  })</pre> | `null` | no |
-| internet\_gateway\_tags | Additional tags to set on the internet gateway| `map(string)` | `{}` | no |
+| internet\_gateway\_tags | Additional tags to set on the internet gateway | `map(string)` | `{}` | no |
 | lambda\_subnet\_bits | The number of bits used for the subnet mask | `number` | `null` | no |
 | postfix | Postfix the role and policy names with Role and Policy | `bool` | `false` | no |
 | prepend\_resource\_type | If set it will prepend the resource type on the name of the resource. | `bool` | `false` | no |

--- a/README.md
+++ b/README.md
@@ -43,7 +43,6 @@ module "full_vpc" {
 | cidr\_block | The CIDR block for the VPC | `string` | n/a | yes |
 | name | Used as part of the resource names to indicate they are created and used within a specific name | `string` | n/a | yes |
 | tags | A mapping of tags to assign to the resources | `map(string)` | n/a | yes |
-| create\_default\_security\_group | Set to false to not a default security group | `bool` | `true` | no |
 | dhcp\_options | DHCP options to assign to the VPC | <pre>object({<br>    domain_name          = string<br>    domain_name_servers  = list(string)<br>    netbios_name_servers = list(string)<br>    netbios_node_type    = number<br>    ntp_servers          = list(string)<br>  })</pre> | `null` | no |
 | ebs\_endpoint | Variables to provision an EBS endpoint to the VPC | <pre>object({<br>    private_dns_enabled = bool<br>    security_group_ids  = list(string)<br>    subnet_ids          = list(string)<br>  })</pre> | `null` | no |
 | ec2\_endpoint | Variables to provision an EC2 endpoint to the VPC | <pre>object({<br>    private_dns_enabled = bool<br>    security_group_ids  = list(string)<br>    subnet_ids          = list(string)<br>  })</pre> | `null` | no |
@@ -60,6 +59,7 @@ module "full_vpc" {
 | private\_subnet\_tags | Additional tags to set on the private subnets | `map(string)` | `{}` | no |
 | public\_subnet\_bits | The number of bits used for the subnet mask | `number` | `null` | no |
 | public\_subnet\_tags | Additional tags to set on the public subnets | `map(string)` | `{}` | no |
+| restrict\_default\_security\_group | Set to true to remove all rules from the default security group | `bool` | `true` | no |
 | share\_private\_subnets | If set it will share the private subnets through resource access manager | `bool` | `false` | no |
 | share\_public\_subnets | If set it will share the public subnets through resource access manager | `bool` | `false` | no |
 | ssm\_endpoint | Variables to provision an SSM endpoint to the VPC | <pre>object({<br>    private_dns_enabled = bool<br>    security_group_ids  = list(string)<br>    subnet_ids          = list(string)<br>  })</pre> | `null` | no |

--- a/main.tf
+++ b/main.tf
@@ -34,7 +34,7 @@ resource "aws_vpc" "default" {
   enable_dns_support   = true
   enable_dns_hostnames = true
   instance_tenancy     = "default"
-  tags                 = merge(
+  tags = merge(
     var.tags,
     { "Name" = "${var.prepend_resource_type ? "vpc-" : ""}${var.name}" },
     var.vpc_custom_tags
@@ -49,7 +49,7 @@ resource "aws_default_security_group" "default" {
 resource "aws_internet_gateway" "default" {
   count  = min(local.public_subnets, 1)
   vpc_id = aws_vpc.default.id
-  tags   = merge(
+  tags = merge(
     var.tags,
     { "Name" = "${var.prepend_resource_type ? "igw-" : ""}${var.name}" },
     var.internet_gateway_custom_tags
@@ -122,7 +122,7 @@ resource "aws_subnet" "lambda" {
 resource "aws_route_table" "public" {
   count  = min(local.public_subnets, 1)
   vpc_id = aws_vpc.default.id
-  tags   = merge(
+  tags = merge(
     var.tags,
     { "Name" = "${var.prepend_resource_type ? "route-table-" : ""}${var.name}-public" }
   )

--- a/main.tf
+++ b/main.tf
@@ -37,7 +37,7 @@ resource "aws_vpc" "default" {
   tags = merge(
     var.tags,
     { "Name" = "${var.prepend_resource_type ? "vpc-" : ""}${var.name}" },
-    var.vpc_custom_tags
+    var.vpc_tags
   )
 }
 
@@ -52,7 +52,7 @@ resource "aws_internet_gateway" "default" {
   tags = merge(
     var.tags,
     { "Name" = "${var.prepend_resource_type ? "igw-" : ""}${var.name}" },
-    var.internet_gateway_custom_tags
+    var.internet_gateway_tags
   )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -42,7 +42,7 @@ resource "aws_vpc" "default" {
 }
 
 resource "aws_default_security_group" "default" {
-  count  = var.create_default_security_group ? 1 : 0
+  count  = var.restrict_default_security_group ? 1 : 0
   vpc_id = aws_vpc.default.id
 }
 

--- a/main.tf
+++ b/main.tf
@@ -51,7 +51,8 @@ resource "aws_internet_gateway" "default" {
   vpc_id = aws_vpc.default.id
   tags   = merge(
     var.tags,
-    { "Name" = "${var.prepend_resource_type ? "igw-" : ""}${var.name}" }
+    { "Name" = "${var.prepend_resource_type ? "igw-" : ""}${var.name}" },
+    var.internet_gateway_custom_tags
   )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -86,8 +86,8 @@ resource "aws_subnet" "public" {
   vpc_id                  = aws_vpc.default.id
 
   tags = merge(
-    var.public_subnet_tags,
     var.tags,
+    var.public_subnet_tags,
     { "Name" = "${var.prepend_resource_type ? "subnet-" : ""}${var.name}-public-${local.az_ids[count.index]}" }
   )
 }
@@ -100,8 +100,8 @@ resource "aws_subnet" "private" {
   vpc_id                  = aws_vpc.default.id
 
   tags = merge(
-    var.private_subnet_tags,
     var.tags,
+    var.private_subnet_tags,
     { "Name" = "${var.prepend_resource_type ? "subnet-" : ""}${var.name}-private-${local.az_ids[count.index]}" }
   )
 }
@@ -122,7 +122,10 @@ resource "aws_subnet" "lambda" {
 resource "aws_route_table" "public" {
   count  = min(local.public_subnets, 1)
   vpc_id = aws_vpc.default.id
-  tags   = merge(var.tags, { "Name" = "${var.prepend_resource_type ? "route-table-" : ""}${var.name}-public" })
+  tags   = merge(
+    var.tags,
+    { "Name" = "${var.prepend_resource_type ? "route-table-" : ""}${var.name}-public" }
+  )
 }
 
 resource "aws_route" "public" {

--- a/main.tf
+++ b/main.tf
@@ -34,18 +34,25 @@ resource "aws_vpc" "default" {
   enable_dns_support   = true
   enable_dns_hostnames = true
   instance_tenancy     = "default"
-  tags                 = merge(var.tags, { "Name" = "${var.prepend_resource_type ? "vpc-" : ""}${var.name}" })
+  tags                 = merge(
+    var.tags,
+    { "Name" = "${var.prepend_resource_type ? "vpc-" : ""}${var.name}" },
+    var.vpc_custom_tags
+  )
 }
 
 resource "aws_default_security_group" "default" {
-  count  = var.restrict_default_security_group ? 1 : 0
+  count  = var.create_default_security_group ? 1 : 0
   vpc_id = aws_vpc.default.id
 }
 
 resource "aws_internet_gateway" "default" {
   count  = min(local.public_subnets, 1)
   vpc_id = aws_vpc.default.id
-  tags   = merge(var.tags, { "Name" = "${var.prepend_resource_type ? "igw-" : ""}${var.name}" })
+  tags   = merge(
+    var.tags,
+    { "Name" = "${var.prepend_resource_type ? "igw-" : ""}${var.name}" }
+  )
 }
 
 resource "aws_eip" "nat" {
@@ -65,7 +72,8 @@ resource "aws_nat_gateway" "default" {
   subnet_id     = aws_subnet.public[count.index].id
 
   tags = merge(
-    var.tags, { "Name" = "${var.prepend_resource_type ? "nat-" : ""}${var.name}-${local.az_ids[count.index]}" }
+    var.tags,
+    { "Name" = "${var.prepend_resource_type ? "nat-" : ""}${var.name}-${local.az_ids[count.index]}" }
   )
 }
 
@@ -77,9 +85,9 @@ resource "aws_subnet" "public" {
   vpc_id                  = aws_vpc.default.id
 
   tags = merge(
-    { "Name" = "${var.prepend_resource_type ? "subnet-" : ""}${var.name}-public-${local.az_ids[count.index]}" },
     var.public_subnet_tags,
-    var.tags
+    var.tags,
+    { "Name" = "${var.prepend_resource_type ? "subnet-" : ""}${var.name}-public-${local.az_ids[count.index]}" }
   )
 }
 
@@ -91,9 +99,9 @@ resource "aws_subnet" "private" {
   vpc_id                  = aws_vpc.default.id
 
   tags = merge(
-    { "Name" = "${var.prepend_resource_type ? "subnet-" : ""}${var.name}-private-${local.az_ids[count.index]}" },
     var.private_subnet_tags,
-    var.tags
+    var.tags,
+    { "Name" = "${var.prepend_resource_type ? "subnet-" : ""}${var.name}-private-${local.az_ids[count.index]}" }
   )
 }
 
@@ -105,7 +113,8 @@ resource "aws_subnet" "lambda" {
   vpc_id                  = aws_vpc.default.id
 
   tags = merge(
-    var.tags, { "Name" = "${var.prepend_resource_type ? "subnet-" : ""}${var.name}-lambda-${local.az_ids[count.index]}" }
+    var.tags,
+    { "Name" = "${var.prepend_resource_type ? "subnet-" : ""}${var.name}-lambda-${local.az_ids[count.index]}" }
   )
 }
 
@@ -133,7 +142,8 @@ resource "aws_route_table" "private" {
   vpc_id = aws_vpc.default.id
 
   tags = merge(
-    var.tags, { "Name" = "${var.prepend_resource_type ? "route-table-" : ""}${var.name}-private-${local.az_ids[count.index]}" }
+    var.tags,
+    { "Name" = "${var.prepend_resource_type ? "route-table-" : ""}${var.name}-private-${local.az_ids[count.index]}" }
   )
 }
 
@@ -155,7 +165,8 @@ resource "aws_route_table" "lambda" {
   vpc_id = aws_vpc.default.id
 
   tags = merge(
-    var.tags, { "Name" = "${var.prepend_resource_type ? "route-table-" : ""}${var.name}-lambda-${local.az_ids[count.index]}" }
+    var.tags,
+    { "Name" = "${var.prepend_resource_type ? "route-table-" : ""}${var.name}-lambda-${local.az_ids[count.index]}" }
   )
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,12 @@ variable "cidr_block" {
   description = "The CIDR block for the VPC"
 }
 
+variable "create_default_security_group" {
+  type        = bool
+  default     = true
+  description = "Set to true to remove all rules from the default security group"
+}
+
 variable "dhcp_options" {
   type = object({
     domain_name          = string
@@ -67,6 +73,12 @@ variable "flow_logs" {
   description = "Variables to enable flow logs for the VPC"
 }
 
+variable "internet_gateway_custom_tags" {
+  type        = map(string)
+  default     = {}
+  description = "Custom tags to be added to the internet_gateway resource, will overwrite generic tags"
+}
+
 variable "lambda_subnet_bits" {
   type        = number
   default     = null
@@ -124,12 +136,6 @@ variable "private_s3_endpoint" {
   description = "Deploy an S3 endpoint for your private subnets"
 }
 
-variable "restrict_default_security_group" {
-  type        = bool
-  default     = true
-  description = "Set to true to remove all rules from the default security group"
-}
-
 variable "share_private_subnets" {
   type        = bool
   default     = false
@@ -170,7 +176,13 @@ variable "subnet_sharing_custom_tags" {
 
 variable "tags" {
   type        = map(string)
-  description = "A mapping of tags to assign to the resources"
+  description = "A mapping of tags to assign to all resources"
+}
+
+variable "vpc_custom_tags" {
+  type        = map(string)
+  default     = {}
+  description = "Custom tags to be added to the VPC resource, will overwrite generic tags"
 }
 
 variable "transfer_server" {

--- a/variables.tf
+++ b/variables.tf
@@ -179,12 +179,6 @@ variable "tags" {
   description = "A mapping of tags to assign to all resources"
 }
 
-variable "vpc_tags" {
-  type        = map(string)
-  default     = {}
-  description = "Additional tags to set on the VPC"
-}
-
 variable "transfer_server" {
   type = object({
     security_group_ids  = list(string)
@@ -193,4 +187,10 @@ variable "transfer_server" {
   })
   default     = null
   description = "Variables to provision a Transfer Server endpoint to the VPC"
+}
+
+variable "vpc_tags" {
+  type        = map(string)
+  default     = {}
+  description = "Additional tags to set on the VPC"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -8,12 +8,6 @@ variable "cidr_block" {
   description = "The CIDR block for the VPC"
 }
 
-variable "create_default_security_group" {
-  type        = bool
-  default     = true
-  description = "Set to true to remove all rules from the default security group"
-}
-
 variable "dhcp_options" {
   type = object({
     domain_name          = string
@@ -134,6 +128,12 @@ variable "private_dynamodb_endpoint" {
 variable "private_s3_endpoint" {
   default     = false
   description = "Deploy an S3 endpoint for your private subnets"
+}
+
+variable "restrict_default_security_group" {
+  type        = bool
+  default     = true
+  description = "Set to true to remove all rules from the default security group"
 }
 
 variable "share_private_subnets" {

--- a/variables.tf
+++ b/variables.tf
@@ -67,10 +67,10 @@ variable "flow_logs" {
   description = "Variables to enable flow logs for the VPC"
 }
 
-variable "internet_gateway_custom_tags" {
+variable "internet_gateway_tags" {
   type        = map(string)
   default     = {}
-  description = "Custom tags to be added to the internet_gateway resource, will overwrite generic tags"
+  description = "Additional tags to set on the internet gateway"
 }
 
 variable "lambda_subnet_bits" {
@@ -179,10 +179,10 @@ variable "tags" {
   description = "A mapping of tags to assign to all resources"
 }
 
-variable "vpc_custom_tags" {
+variable "vpc_tags" {
   type        = map(string)
   default     = {}
-  description = "Custom tags to be added to the VPC resource, will overwrite generic tags"
+  description = "Additional tags to set on the VPC"
 }
 
 variable "transfer_server" {


### PR DESCRIPTION
This MR Allows for 

- custom tags on the VPC itself, which are not applied to all resources.
- custom tags on the Internat gateway
- Order of precedence for these tags is changed, allowing the Name to be set by the custom tag
- Changed the order of merging of tags on other resources
