### PR TITLE
Make public subnets map_public_ip_on_launch configurable

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -47,4 +47,4 @@ jobs:
       - name: Check out code
         uses: actions/checkout@master
       - name: Terraform security scan
-        uses: triat/terraform-security-scan@v2.0.2
+        uses: triat/terraform-security-scan@v2.2.3

--- a/main.tf
+++ b/main.tf
@@ -82,7 +82,7 @@ resource "aws_subnet" "public" {
   count                   = local.public_subnets
   cidr_block              = local.cidr_blocks[count.index]
   availability_zone       = var.availability_zones[count.index]
-  map_public_ip_on_launch = var.public_subnet_map_public_ip_on_launch
+  map_public_ip_on_launch = var.map_public_ip_on_launch
   vpc_id                  = aws_vpc.default.id
 
   tags = merge(

--- a/main.tf
+++ b/main.tf
@@ -82,7 +82,7 @@ resource "aws_subnet" "public" {
   count                   = local.public_subnets
   cidr_block              = local.cidr_blocks[count.index]
   availability_zone       = var.availability_zones[count.index]
-  map_public_ip_on_launch = true
+  map_public_ip_on_launch = var.public_subnet_map_public_ip_on_launch
   vpc_id                  = aws_vpc.default.id
 
   tags = merge(

--- a/variables.tf
+++ b/variables.tf
@@ -79,6 +79,12 @@ variable "lambda_subnet_bits" {
   description = "The number of bits used for the subnet mask"
 }
 
+variable "map_public_ip_on_launch" {
+  type        = bool
+  default     = false
+  description = "Whether public IP addresses are assigned on instance launch"
+}
+
 variable "name" {
   type        = string
   description = "Used as part of the resource names to indicate they are created and used within a specific name"
@@ -100,12 +106,6 @@ variable "private_subnet_bits" {
   type        = number
   default     = null
   description = "The number of bits used for the subnet mask"
-}
-
-variable "public_subnet_map_public_ip_on_launch" {
-  type        = bool
-  default     = false
-  description = "If set, network interfaces created in the public subnet automatically receives a public IPV4 address"
 }
 
 variable "private_subnet_tags" {

--- a/variables.tf
+++ b/variables.tf
@@ -102,6 +102,12 @@ variable "private_subnet_bits" {
   description = "The number of bits used for the subnet mask"
 }
 
+variable "public_subnet_map_public_ip_on_launch" {
+  type        = bool
+  default     = false
+  description = "If set, network interfaces created in the public subnet automatically receives a public IPV4 address"
+}
+
 variable "private_subnet_tags" {
   type        = map(string)
   default     = {}

--- a/versions.tf
+++ b/versions.tf
@@ -1,3 +1,9 @@
 terraform {
   required_version = ">= 0.12.10"
+
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
 }


### PR DESCRIPTION
AWS Security hub suggests the `MapPublicIpOnLaunch` to be set to false. ([Source](https://docs.aws.amazon.com/securityhub/latest/userguide/securityhub-standards-fsbp-controls.html#ec2-15-remediation))

Agree on this, but to prevent existing setups to fail made it a setting, so existing implementation (or if you really want to deviate, you can).

Also:
- Fixed provider configuration
- Updated TFSec in the Github actions (failed)