### PR TITLE
Shared public subnets

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -121,7 +121,7 @@ resource "aws_subnet" "lambda" {
 }
 
 resource "aws_route_table" "public" {
-  count  = min(local.public_subnets, 1)
+  count = var.shared_public_route_table ? min(local.public_subnets, 1): local.public_subnets
   vpc_id = aws_vpc.default.id
   tags = merge(
     var.tags,
@@ -139,7 +139,7 @@ resource "aws_route" "public" {
 resource "aws_route_table_association" "public" {
   count          = local.public_subnets
   subnet_id      = aws_subnet.public[count.index].id
-  route_table_id = aws_route_table.public[0].id
+  route_table_id = var.shared_public_route_table ? aws_route_table.public[0].id : aws_route_table.public[count.index].id
 }
 
 resource "aws_route_table" "private" {

--- a/main.tf
+++ b/main.tf
@@ -121,7 +121,7 @@ resource "aws_subnet" "lambda" {
 }
 
 resource "aws_route_table" "public" {
-  count = var.shared_public_route_table ? min(local.public_subnets, 1): local.public_subnets
+  count  = var.shared_public_route_table ? min(local.public_subnets, 1) : local.public_subnets
   vpc_id = aws_vpc.default.id
   tags = merge(
     var.tags,

--- a/variables.tf
+++ b/variables.tf
@@ -174,16 +174,16 @@ variable "share_private_subnets" {
   description = "If set it will share the private subnets through resource access manager"
 }
 
-variable "shared_public_route_table" {
-  type        = bool
-  default     = true
-  description = "Determines weather to use a single route table for all public networks"
-}
-
 variable "share_public_subnets" {
   type        = bool
   default     = false
   description = "If set it will share the public subnets through resource access manager"
+}
+
+variable "shared_public_route_table" {
+  type        = bool
+  default     = true
+  description = "Determines weather to use a single route table for all public networks"
 }
 
 variable "ssm_endpoint" {

--- a/variables.tf
+++ b/variables.tf
@@ -174,6 +174,12 @@ variable "share_private_subnets" {
   description = "If set it will share the private subnets through resource access manager"
 }
 
+variable "shared_public_route_table" {
+  description = "Controls if public subnet routing will be handled by one shared route table or one per subnet"
+  type        = bool
+  default     = true
+}
+
 variable "share_public_subnets" {
   type        = bool
   default     = false

--- a/variables.tf
+++ b/variables.tf
@@ -175,7 +175,7 @@ variable "share_private_subnets" {
 }
 
 variable "shared_public_route_table" {
-  description = "Controls if public subnet routing will be handled by one shared route table or one per subnet"
+  description = "Controls if public subnet routing will be handled by a shared route table or one table per subnet"
   type        = bool
   default     = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -175,9 +175,9 @@ variable "share_private_subnets" {
 }
 
 variable "shared_public_route_table" {
-  description = "Controls if public subnet routing will be handled by a shared route table or one table per subnet"
   type        = bool
   default     = true
+  description = "Determines weather to use a single route table for all public networks"
 }
 
 variable "share_public_subnets" {


### PR DESCRIPTION
Allows user to choose to seperate the public route tables to allow for (for example) per AZ routing. Use case is egress scanning via appliances need to communicate with a gateway loadbalancer in the same availability zone. 