### PR TITLE
always count public subnets for route table as we can have 0 1 or many.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -130,7 +130,7 @@ resource "aws_route_table" "public" {
 }
 
 resource "aws_route" "public" {
-  count                  = local.public_subnets
+  count                  = var.shared_public_route_table ? min(local.public_subnets, 1) : local.public_subnets
   route_table_id         = aws_route_table.public[count.index].id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = aws_internet_gateway.default[0].id

--- a/main.tf
+++ b/main.tf
@@ -130,8 +130,8 @@ resource "aws_route_table" "public" {
 }
 
 resource "aws_route" "public" {
-  count                  = min(local.public_subnets, 1)
-  route_table_id         = aws_route_table.public[0].id
+  count                  = local.public_subnets
+  route_table_id         = aws_route_table.public[count.index].id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = aws_internet_gateway.default[0].id
 }


### PR DESCRIPTION
This is required as v1.13.0 supports one or many public subnets so we should always count and associate igw route with the count of subnets.

