### PR TITLE
Update route table names based on shared_public_route_table value.

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -126,7 +126,7 @@ resource "aws_route_table" "public" {
   tags = merge(
     var.tags,
     {
-      "Name" = var.shared_public_route_table ? "${var.prepend_resource_type ? "route-table-" : ""}${var.name}-public" : "${var.prepend_resource_type ? "route-table-" : ""}${var.name}-public-${local.az_ids[count.index]}"
+        "Name" = "${var.prepend_resource_type ? "route-table-" : ""}${var.name}-public${var.shared_public_route_table ?  : "-${local.az_ids[count.index]}"}"
     }
   )
 }

--- a/main.tf
+++ b/main.tf
@@ -126,7 +126,7 @@ resource "aws_route_table" "public" {
   tags = merge(
     var.tags,
     {
-        "Name" = "${var.prepend_resource_type ? "route-table-" : ""}${var.name}-public${var.shared_public_route_table ?  : "-${local.az_ids[count.index]}"}"
+        "Name" = "${var.prepend_resource_type ? "route-table-" : ""}${var.name}-public${var.shared_public_route_table ? "" : "-${local.az_ids[count.index]}"}"
     }
   )
 }

--- a/main.tf
+++ b/main.tf
@@ -126,7 +126,7 @@ resource "aws_route_table" "public" {
   tags = merge(
     var.tags,
     {
-        "Name" = "${var.prepend_resource_type ? "route-table-" : ""}${var.name}-public${var.shared_public_route_table ? "" : "-${local.az_ids[count.index]}"}"
+      "Name" = "${var.prepend_resource_type ? "route-table-" : ""}${var.name}-public${var.shared_public_route_table ? "" : "-${local.az_ids[count.index]}"}"
     }
   )
 }

--- a/main.tf
+++ b/main.tf
@@ -125,7 +125,7 @@ resource "aws_route_table" "public" {
   vpc_id = aws_vpc.default.id
   tags = merge(
     var.tags,
-    { "Name" = "${var.prepend_resource_type ? "route-table-" : ""}${var.name}-public" }
+    { "Name" = var.shared_public_route_table ? "${var.prepend_resource_type ? "route-table-" : ""}${var.name}-public" : "${var.prepend_resource_type ? "route-table-" : ""}${var.name}-public-${local.az_ids[count.index]}"}
   )
 }
 

--- a/main.tf
+++ b/main.tf
@@ -125,7 +125,9 @@ resource "aws_route_table" "public" {
   vpc_id = aws_vpc.default.id
   tags = merge(
     var.tags,
-    { "Name" = var.shared_public_route_table ? "${var.prepend_resource_type ? "route-table-" : ""}${var.name}-public" : "${var.prepend_resource_type ? "route-table-" : ""}${var.name}-public-${local.az_ids[count.index]}"}
+    {
+      "Name" = var.shared_public_route_table ? "${var.prepend_resource_type ? "route-table-" : ""}${var.name}-public" : "${var.prepend_resource_type ? "route-table-" : ""}${var.name}-public-${local.az_ids[count.index]}"
+    }
   )
 }
 


### PR DESCRIPTION
If we use multiple route tables they shouldn't share the same name.