### PR TITLE
Add support for permission boundary policies to Flow Logs IAM Role

### DIFF
--- a/flowlogs.tf
+++ b/flowlogs.tf
@@ -25,7 +25,6 @@ module "flow_logs_role" {
   permissions_boundary  = var.flow_logs.iam_role_boundary_policy
   postfix               = var.postfix
   tags                  = var.tags
-
 }
 
 resource "aws_cloudwatch_log_group" "flow_logs" {

--- a/flowlogs.tf
+++ b/flowlogs.tf
@@ -22,7 +22,7 @@ module "flow_logs_role" {
   principal_type        = "Service"
   principal_identifiers = ["vpc-flow-logs.amazonaws.com"]
   role_policy           = data.aws_iam_policy_document.log_stream_action.json
-  permissions_boundary =  var.flow_logs.iam_role_boundary_policy
+  permissions_boundary  = var.flow_logs.iam_role_boundary_policy
   postfix               = var.postfix
   tags                  = var.tags
 

--- a/flowlogs.tf
+++ b/flowlogs.tf
@@ -17,13 +17,15 @@ data "aws_iam_policy_document" "log_stream_action" {
 
 module "flow_logs_role" {
   count                 = var.flow_logs != null ? 1 : 0
-  source                = "github.com/schubergphilis/terraform-aws-mcaf-role?ref=v0.3.0"
+  source                = "github.com/schubergphilis/terraform-aws-mcaf-role?ref=v0.3.2"
   name                  = var.flow_logs.iam_role_name
   principal_type        = "Service"
   principal_identifiers = ["vpc-flow-logs.amazonaws.com"]
   role_policy           = data.aws_iam_policy_document.log_stream_action.json
+  permissions_boundary =  var.flow_logs.iam_role_boundary_policy
   postfix               = var.postfix
   tags                  = var.tags
+
 }
 
 resource "aws_cloudwatch_log_group" "flow_logs" {

--- a/flowlogs.tf
+++ b/flowlogs.tf
@@ -22,7 +22,7 @@ module "flow_logs_role" {
   principal_type        = "Service"
   principal_identifiers = ["vpc-flow-logs.amazonaws.com"]
   role_policy           = data.aws_iam_policy_document.log_stream_action.json
-  permissions_boundary  = var.flow_logs.iam_role_boundary_policy
+  permissions_boundary  = var.flow_logs.iam_role_permission_boundary
   postfix               = var.postfix
   tags                  = var.tags
 }

--- a/variables.tf
+++ b/variables.tf
@@ -74,8 +74,8 @@ variable "enable_private_default_route" {
 
 variable "flow_logs" {
   type = object({
-    iam_role_name            = string
     iam_role_boundary_policy = string
+    iam_role_name            = string
     log_group_name           = string
     retention_in_days        = number
     traffic_type             = string

--- a/variables.tf
+++ b/variables.tf
@@ -74,12 +74,11 @@ variable "enable_private_default_route" {
 
 variable "flow_logs" {
   type = object({
-    iam_role_name     = string
+    iam_role_name            = string
     iam_role_boundary_policy = string
-    log_group_name    = string
-    retention_in_days = number
-    traffic_type      = string
-    
+    log_group_name           = string
+    retention_in_days        = number
+    traffic_type             = string
   })
   default     = null
   description = "Variables to enable flow logs for the VPC"

--- a/variables.tf
+++ b/variables.tf
@@ -74,11 +74,11 @@ variable "enable_private_default_route" {
 
 variable "flow_logs" {
   type = object({
-    iam_role_boundary_policy = string
-    iam_role_name            = string
-    log_group_name           = string
-    retention_in_days        = number
-    traffic_type             = string
+    iam_role_name                = string
+    iam_role_permission_boundary = string
+    log_group_name               = string
+    retention_in_days            = number
+    traffic_type                 = string
   })
   default     = null
   description = "Variables to enable flow logs for the VPC"

--- a/variables.tf
+++ b/variables.tf
@@ -75,9 +75,11 @@ variable "enable_private_default_route" {
 variable "flow_logs" {
   type = object({
     iam_role_name     = string
+    iam_role_boundary_policy = string
     log_group_name    = string
     retention_in_days = number
     traffic_type      = string
+    
   })
   default     = null
   description = "Variables to enable flow logs for the VPC"


### PR DESCRIPTION
- adds support for specifying iam_role_boundary_policy when configuring flow logs
- bumped role module to 0.3.2 
- iam_role_boundary_policy can be set to null to retain previous behaviour (although cannot be set to null by default)