### PR TITLE
Add support for a CodeBuild interface VPC endpoint

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -47,4 +47,4 @@ jobs:
       - name: Check out code
         uses: actions/checkout@master
       - name: Terraform security scan
-        uses: triat/terraform-security-scan@v3.0.0
+        uses: triat/terraform-security-scan@v3.0.3

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 #  Local .terraform directories
 **/.terraform/*
+*.lock.hcl
 
 # .tfstate files
 *.tfstate

--- a/endpoints.tf
+++ b/endpoints.tf
@@ -2,6 +2,18 @@ locals {
   s3_route_table_ids = var.s3_route_table_ids != null ? var.s3_route_table_ids : aws_route_table.private[*].id
 }
 
+# Resources for the CodeBuild VPC interface endpoint
+resource "aws_vpc_endpoint" "codebuild_interface_endpoint" {
+  count               = var.codebuild_interface_endpoint != null ? 1 : 0
+  private_dns_enabled = var.codebuild_interface_endpoint.private_dns_enabled
+  security_group_ids  = var.codebuild_interface_endpoint.security_group_ids
+  service_name        = "com.amazonaws.${data.aws_region.current.name}.codebuild"
+  subnet_ids          = var.codebuild_interface_endpoint.subnet_ids
+  vpc_endpoint_type   = "Interface"
+  vpc_id              = aws_vpc.default.id
+  tags                = merge(var.tags, { "Name" = "${var.prepend_resource_type ? "endpoint-" : ""}codebuild-interface-${var.name}" })
+}
+
 # Resources for the DynamoDB VPC service endpoint
 resource "aws_vpc_endpoint" "dynamodb" {
   count             = var.private_dynamodb_endpoint ? 1 : 0

--- a/variables.tf
+++ b/variables.tf
@@ -9,6 +9,16 @@ variable "cidr_block" {
   description = "The CIDR block for the VPC"
 }
 
+variable "codebuild_interface_endpoint" {
+  type = object({
+    private_dns_enabled = bool
+    security_group_ids  = list(string)
+    subnet_ids          = list(string)
+  })
+  default     = null
+  description = "Variables to provision a CodeBuild endpoint to the VPC"
+}
+
 variable "dhcp_options" {
   type = object({
     domain_name          = string


### PR DESCRIPTION
This PR adds support to create an interface endpoint for `Codebuild`.

See also: https://docs.aws.amazon.com/codebuild/latest/userguide/use-vpc-endpoints-with-codebuild.html