### PR TITLE
Resolve eip deprecation warning

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -29,6 +29,7 @@ locals {
 
 data "aws_region" "current" {}
 
+#tfsec:ignore:aws-ec2-require-vpc-flow-logs-for-all-vpcs
 resource "aws_vpc" "default" {
   cidr_block           = var.cidr_block
   enable_dns_hostnames = true

--- a/main.tf
+++ b/main.tf
@@ -60,8 +60,8 @@ resource "aws_internet_gateway" "default" {
 }
 
 resource "aws_eip" "nat" {
-  count = var.enable_nat_gateway ? local.public_subnets : 0
-  vpc   = true
+  count  = var.enable_nat_gateway ? local.public_subnets : 0
+  domain = "vpc"
 
   tags = merge(
     var.tags, { "Name" = "${var.prepend_resource_type ? "eip-" : ""}nat-${var.name}-${local.az_ids[count.index]}" }

--- a/versions.tf
+++ b/versions.tf
@@ -3,7 +3,8 @@ terraform {
 
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">= 5.0.0"
     }
   }
 }


### PR DESCRIPTION
This PR resolved the `aws_eip` deprecation warning that's introduced in [provider v5](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md#500-may-25-2023):

```Warning: Argument is deprecated
with xxx.vpc.aws_eip.nat[1]
on xxx/main.tf line 64, in resource "aws_eip" "nat":
  vpc   = true
use domain attribute instead

```

Also disabled the flowlog check in tfsec

Links:
- https://github.com/hashicorp/terraform-provider-aws/pull/31567
- https://github.com/hashicorp/terraform-provider-aws/issues/26714
- https://github.com/aquasecurity/tfsec/issues/2024

