### PR TITLE
Option to store VPC flowlogs in a S3 bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,8 @@ module "full_vpc" {
 | ec2messages\_endpoint | Variables to provision an EC2 messages endpoint to the VPC | <pre>object({<br>    private_dns_enabled = bool<br>    security_group_ids  = list(string)<br>    subnet_ids          = list(string)<br>  })</pre> | `null` | no |
 | ecr\_api\_endpoint | Variables to provision a ECR endpoint to the VPC | <pre>object({<br>    private_dns_enabled = bool<br>    security_group_ids  = list(string)<br>    subnet_ids          = list(string)<br>  })</pre> | `null` | no |
 | enable\_nat\_gateway | Set to true to provision a NAT Gateway for each private subnet | `bool` | `true` | no |
-| flow\_logs | Variables to enable flow logs for the VPC | <pre>object({<br>    iam_role_name     = string<br>    log_group_name    = string<br>    retention_in_days = number<br>    traffic_type      = string<br>  })</pre> | `null` | no |
+| flow\_logs\_s3 | Variables to enable flow logs for the VPC stored in an S3 bucket| <pre>object({<br>    bucket_name    = optional(string, true)<br>    create_bucket = optional(bool, true)<br>    retention_in_Days = number<br>    traffic_type      = string<br>  })</pre> | `null` | no |
+| flow\_logs | Variables to enable flow logs for the VPC stored in CloudWatch Logs| <pre>object({<br>    iam_role_name     = string<br>    log_group_name    = string<br>    retention_in_days = number<br>    traffic_type      = string<br>  })</pre> | `null` | no |
 | internet\_gateway\_tags | Additional tags to set on the internet gateway | `map(string)` | `{}` | no |
 | lambda\_subnet\_bits | The number of bits used for the subnet mask | `number` | `null` | no |
 | logs\_endpoint | Variables to provision a Log endpoint to the VPC | <pre>object({<br>    private_dns_enabled = bool<br>    security_group_ids  = list(string)<br>    subnet_ids          = list(string)<br>  })</pre> | `null` | no |

--- a/flowlogs.tf
+++ b/flowlogs.tf
@@ -39,6 +39,7 @@ resource "aws_flow_log" "flow_logs" {
   iam_role_arn         = module.flow_logs_role[count.index].arn
   log_destination      = aws_cloudwatch_log_group.flow_logs[count.index].arn
   log_destination_type = "cloud-watch-logs"
+  log_format           = var.flow_logs.log_format
   traffic_type         = var.flow_logs.traffic_type
   vpc_id               = aws_vpc.default.id
   tags                 = var.tags

--- a/flowlogs.tf
+++ b/flowlogs.tf
@@ -35,10 +35,11 @@ resource "aws_cloudwatch_log_group" "flow_logs" {
 }
 
 resource "aws_flow_log" "flow_logs" {
-  count           = var.flow_logs != null ? 1 : 0
-  iam_role_arn    = module.flow_logs_role[count.index].arn
-  log_destination = aws_cloudwatch_log_group.flow_logs[count.index].arn
-  traffic_type    = var.flow_logs.traffic_type
-  vpc_id          = aws_vpc.default.id
-  tags            = var.tags
+  count                = var.flow_logs != null ? 1 : 0
+  iam_role_arn         = module.flow_logs_role[count.index].arn
+  log_destination      = aws_cloudwatch_log_group.flow_logs[count.index].arn
+  log_destination_type = "cloud-watch-logs"
+  traffic_type         = var.flow_logs.traffic_type
+  vpc_id               = aws_vpc.default.id
+  tags                 = var.tags
 }

--- a/flowlogs_s3.tf
+++ b/flowlogs_s3.tf
@@ -75,6 +75,7 @@ resource "aws_flow_log" "flow_logs_s3" {
   count                = local.store_logs_in_s3 ? 1 : 0
   log_destination      = local.create_bucket ? module.log_bucket[count.index].arn : var.flow_logs_s3.bucket_arn
   log_destination_type = "s3"
+  log_format           = var.flow_logs_s3.log_format
   traffic_type         = var.flow_logs_s3.traffic_type
   vpc_id               = aws_vpc.default.id
   tags                 = var.tags

--- a/flowlogs_s3.tf
+++ b/flowlogs_s3.tf
@@ -45,7 +45,7 @@ module "log_bucket" {
                     "s3:x-amz-acl": "bucket-owner-full-control"
                 },
                 "ArnLike": {
-                    "aws:SourceArn": "arn:aws:logs:eu-west-1:${data.aws_caller_identity.current.account_id}:*"
+                    "aws:SourceArn": "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
                 }
             }
         },
@@ -62,7 +62,7 @@ module "log_bucket" {
                     "aws:SourceAccount": "${data.aws_caller_identity.current.account_id}"
                 },
                 "ArnLike": {
-                    "aws:SourceArn": "arn:aws:logs:eu-west-1:${data.aws_caller_identity.current.account_id}:*"
+                    "aws:SourceArn": "arn:aws:logs:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:*"
                 }
             }
         }

--- a/flowlogs_s3.tf
+++ b/flowlogs_s3.tf
@@ -1,0 +1,81 @@
+locals {
+  store_logs_in_s3 = (var.flow_logs_s3 != null)
+  create_bucket    = var.flow_logs_s3 != null && try(var.flow_logs_s3.bucket_arn == null, false)
+}
+
+module "log_bucket" {
+  source = "github.com/schubergphilis/terraform-aws-mcaf-s3?ref=v0.12.1"
+  count  = local.create_bucket ? 1 : 0
+
+  name       = var.flow_logs_s3.bucket_name
+  versioning = true
+
+  tags = var.tags
+
+  lifecycle_rule = [
+    {
+      id      = "retention"
+      enabled = true
+
+      abort_incomplete_multipart_upload = {
+        days_after_initiation = 7
+      }
+
+      noncurrent_version_expiration = {
+        noncurrent_days = var.flow_logs_s3.retention_in_days
+      }
+    }
+  ]
+
+  policy = <<EOF
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "AWSLogDeliveryWrite",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "delivery.logs.amazonaws.com"
+            },
+            "Action": "s3:PutObject",
+            "Resource": "arn:aws:s3:::${var.flow_logs_s3.bucket_name}/AWSLogs/${data.aws_caller_identity.current.account_id}/*",
+            "Condition": {
+                "StringEquals": {
+                    "aws:SourceAccount": "${data.aws_caller_identity.current.account_id}",
+                    "s3:x-amz-acl": "bucket-owner-full-control"
+                },
+                "ArnLike": {
+                    "aws:SourceArn": "arn:aws:logs:eu-west-1:${data.aws_caller_identity.current.account_id}:*"
+                }
+            }
+        },
+        {
+            "Sid": "AWSLogDeliveryAclCheck",
+            "Effect": "Allow",
+            "Principal": {
+                "Service": "delivery.logs.amazonaws.com"
+            },
+            "Action": "s3:GetBucketAcl",
+            "Resource": "arn:aws:s3:::${var.flow_logs_s3.bucket_name}",
+            "Condition": {
+                "StringEquals": {
+                    "aws:SourceAccount": "${data.aws_caller_identity.current.account_id}"
+                },
+                "ArnLike": {
+                    "aws:SourceArn": "arn:aws:logs:eu-west-1:${data.aws_caller_identity.current.account_id}:*"
+                }
+            }
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_flow_log" "flow_logs_s3" {
+  count                = local.store_logs_in_s3 ? 1 : 0
+  log_destination      = local.create_bucket ? module.log_bucket[count.index].arn : var.flow_logs_s3.bucket_arn
+  log_destination_type = "s3"
+  traffic_type         = var.flow_logs_s3.traffic_type
+  vpc_id               = aws_vpc.default.id
+  tags                 = var.tags
+}

--- a/main.tf
+++ b/main.tf
@@ -28,6 +28,7 @@ locals {
 }
 
 data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
 
 #tfsec:ignore:aws-ec2-require-vpc-flow-logs-for-all-vpcs
 resource "aws_vpc" "default" {

--- a/variables.tf
+++ b/variables.tf
@@ -87,6 +87,7 @@ variable "flow_logs_s3" {
   type = object({
     bucket_name       = optional(string, null)
     bucket_arn        = optional(string, null)
+    log_format        = optional(string, null)
     retention_in_days = number
     traffic_type      = string
   })
@@ -98,6 +99,7 @@ variable "flow_logs" {
   type = object({
     iam_role_name                = string
     iam_role_permission_boundary = optional(string, null)
+    log_format                   = optional(string, null)
     log_group_name               = string
     retention_in_days            = number
     traffic_type                 = string

--- a/variables.tf
+++ b/variables.tf
@@ -83,10 +83,21 @@ variable "enable_private_default_route" {
   description = "Set to true to add a default route to the NAT gateway for each private subnet"
 }
 
+variable "flow_logs_s3" {
+  type = object({
+    bucket_name       = optional(string, null)
+    bucket_arn        = optional(string, null)
+    retention_in_days = number
+    traffic_type      = string
+  })
+  default     = null
+  description = "Variables to enable flow logs stored in S3 for the VPC. When bucket_arn is specified, it will not create a new bucket."
+}
+
 variable "flow_logs" {
   type = object({
     iam_role_name                = string
-    iam_role_permission_boundary = string
+    iam_role_permission_boundary = optional(string, null)
     log_group_name               = string
     retention_in_days            = number
     traffic_type                 = string


### PR DESCRIPTION
Hi there,

I'd like to offer this PR as a way to extend the functionality of the VPC Flow Logs. Our usecase results in a way of working where VPC Flow Logs are loaded in an external application for correlation purposes, based on storage in an S3 bucket.

This PR will extend the functionality of the terraform-aws-mcaf-vpc module, and introduce an optional field "**flow_logs_s3**" that can be used (in conjunction, for hybrid log parsing purposes) to configure an S3 destination for flow logs.

The module is extended so it can either create the required bucket, with necessary permissions, as well as using an existing bucket (for example in a different AWS account).

I decided to create a seperate attribute to the vpc module with the postfix _s3, and not touch the existing attribute "flow_logs", as this will allow both attributes to be used, while naming wise be in alignment of the [default log-destination-type of the vpc_flow_log resource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/flow_log#log_destination_type) 

Any thoughts/feedback of the chosen implementation is appreciated 