### PR TITLE
fix: Remove hardcoded role name suffix

### DIFF
--- a/flowlogs.tf
+++ b/flowlogs.tf
@@ -20,8 +20,8 @@ module "flow_logs_role" {
   source  = "schubergphilis/mcaf-role/aws"
   version = "~> 0.5.3"
 
-  name                  = var.flow_logs_cloudwatch.iam_role_name != null ? "${var.flow_logs_cloudwatch.iam_role_name}${title(var.name)}" : null
-  name_prefix           = var.flow_logs_cloudwatch.iam_role_name_prefix != null ? "${var.flow_logs_cloudwatch.iam_role_name_prefix}${title(var.name)}" : null
+  name                  = var.flow_logs_cloudwatch.iam_role_name != null ? var.flow_logs_cloudwatch.iam_role_name : null
+  name_prefix           = var.flow_logs_cloudwatch.iam_role_name_prefix != null ? var.flow_logs_cloudwatch.iam_role_name_prefix : null
   path                  = var.flow_logs_cloudwatch.iam_role_path
   permissions_boundary  = var.flow_logs_cloudwatch.iam_role_permission_boundary
   postfix               = var.flow_logs_cloudwatch.iam_role_postfix


### PR DESCRIPTION
## :hammer_and_wrench: Summary

Remove the unexpected and uncontrollable IAM role creation.

## :rocket: Motivation

While migrating from V1 to V3 of this module, It tried to recreate the FlowLogs role because it hardcoded adds the name to a name that I specify. This causes unwanted recreation of the role:

```hcl
     ~ name                  = "vpc-flowlogs-name" -> "vpc-flowlogs-nameName" # forces replacement
```

Since the name is passed explicitly, I don't understand why it's postfixed with a hardcoded value. Remove this behaviour.
